### PR TITLE
Add keyboard shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,17 @@
     var $ = Zepto;
     var copySourceElemSelector = '#translation_container #action_copy_source';
 
+    // Catch the keyboard shortcut specified in manifest
+    chrome.runtime.onMessage.addListener(function(message) {
+        switch (message.action) {
+            case "translate-math":
+                $('#translate_math').click();
+                break;
+            default:
+                break;
+        }
+    });
+
     // Users need to set the lang manually in plugin options!
     var openOptions = function () {
         chrome.runtime.sendMessage({"action": "openOptionsPage"});
@@ -46,12 +57,12 @@
     var initializePlugin = function() {
 
         $menu = $(copySourceElemSelector).parent();
-        $changeFormatBtn = $('<button tabindex="-1" title="Copy Source & translate math notation" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
+        $translateMathBtn = $('<button id="translate_math" tabindex="-1" title="Copy Source & Translate Math" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
         $translation = $('#translation');
 
         commaURL = chrome.runtime.getURL("5commastyle.gif");
-        $changeFormatBtn.css('background', `url("${commaURL}") 3px 7px no-repeat`);
-        $menu.append($changeFormatBtn);
+        $translateMathBtn.css('background', `url("${commaURL}") 3px 7px no-repeat`);
+        $menu.append($translateMathBtn);
 
         var copyAndTranslateMath = function(lang) {
             $('#action_copy_source').click();
@@ -80,7 +91,7 @@
             getLocale(copyAndTranslateMath);
         }
 
-        $changeFormatBtn.on('click', checkLocale);
+        $translateMathBtn.on('click', checkLocale);
     };
 
     //Crowdin window is generated dynamically so we need to wait for the parent element to be built

--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 (function () {
     var $ = Zepto;
     var copySourceElemSelector = '#translation_container #action_copy_source';
+    var isMac = (/mac/i).test(navigator.platform);
 
     // Catch the keyboard shortcut specified in manifest
     chrome.runtime.onMessage.addListener(function(message) {
@@ -13,7 +14,7 @@
         }
     });
 
-    // Catch and block the Crowdin defualt Keyboard shortcut
+    // Catch and block the Crowdin default keyboard shortcut
     // NOTE: We could actually just press our button here
     // but using chrome.commmands in manigest allows
     // users to customize the Keyboard shortcut
@@ -67,8 +68,15 @@
 
     var initializePlugin = function() {
 
-        // Creating new button
-        $translateMathBtn = $('<button id="translate_math" tabindex="-1" title="Copy Source & Translate Math (Alt+C)" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
+        // Create a new button
+        $translateMathBtn = $('<button id="translate_math" tabindex="-1" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
+        var shortcut;
+        if(isMac)
+          shortcut = " (Cmd+C)" 
+        else
+          shortcut = " (Alt+C)"
+        title = "Copy Source & Translate Math " + shortcut
+        $translateMathBtn.attr("title", title)
         commaURL = chrome.runtime.getURL("5commastyle.gif");
         $translateMathBtn.css('background', `url("${commaURL}") 3px 7px no-repeat`);
 

--- a/app.js
+++ b/app.js
@@ -67,15 +67,22 @@
 
     var initializePlugin = function() {
 
-        $menu = $(copySourceElemSelector).parent();
-        $translateMathBtn = $('<button id="translate_math" tabindex="-1" title="Copy Source & Translate Math" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
-        $translation = $('#translation');
-
+        // Creating new button
+        $translateMathBtn = $('<button id="translate_math" tabindex="-1" title="Copy Source & Translate Math (Alt+C)" class="btn btn-icon"><i class="static-icon-copy"></i></button>');
         commaURL = chrome.runtime.getURL("5commastyle.gif");
         $translateMathBtn.css('background', `url("${commaURL}") 3px 7px no-repeat`);
+
+        $copySourceBtn = $(copySourceElemSelector);
+        $menu = $copySourceBtn.parent();
         $menu.append($translateMathBtn);
 
+        // Default keyboard now clicks our new button instead
+        // so change the title of the original button
+        $copySourceBtn.attr("title", "Copy Source");
+
         var copyAndTranslateMath = function(lang) {
+            $translation = $('#translation');
+            // Click the original button
             $('#action_copy_source').click();
 
             // This is where we actually translate math

--- a/app.js
+++ b/app.js
@@ -13,6 +13,17 @@
         }
     });
 
+    // Catch and block the Crowdin defualt Keyboard shortcut
+    // NOTE: We could actually just press our button here
+    // but using chrome.commmands in manigest allows
+    // users to customize the Keyboard shortcut
+    $(document).on("keydown", function(e) {
+        if (e.code === "KeyC" &&
+           (e.altKey || e.metaKey) && !e.ctrlKey && !e.shiftKey) {
+            e.stopImmediatePropagation();
+        }
+    });
+
     // Users need to set the lang manually in plugin options!
     var openOptions = function () {
         chrome.runtime.sendMessage({"action": "openOptionsPage"});

--- a/background.js
+++ b/background.js
@@ -14,6 +14,15 @@ chrome.runtime.onMessage.addListener(function(message) {
     }
 });
 
+chrome.commands.onCommand.addListener(function (command) {
+    if (command === "translate-math") {
+      //Send keyboard shortcut click to the current tab
+      chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+        chrome.tabs.sendMessage(tabs[0].id, {"action": "translate-math"});
+      });
+    }
+});
+
 function openOptionsPage(){
     chrome.runtime.openOptionsPage();
 }

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "translate-math": {
     "suggested_key": {
       "default": "Alt+X",
-      "mac": "Ctrl+C"
+      "mac": "Command+C"
     },
     "description": "Click 'translate-math' button"
   }

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,15 @@
     "open_in_tab": true,
     "browser_style": true
   },
+"commands": {
+  "translate-math": {
+    "suggested_key": {
+      "default": "Alt+C",
+      "mac": "Ctrl+C"
+    },
+    "description": "Click 'translate-math' button"
+  }
+ },
   "content_scripts": [
     {
       "matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
 "commands": {
   "translate-math": {
     "suggested_key": {
-      "default": "Alt+X",
+      "default": "Alt+C",
       "mac": "Command+C"
     },
     "description": "Click 'translate-math' button"

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
 "commands": {
   "translate-math": {
     "suggested_key": {
-      "default": "Alt+C",
+      "default": "Alt+X",
       "mac": "Ctrl+C"
     },
     "description": "Click 'translate-math' button"

--- a/pack_plugin.sh
+++ b/pack_plugin.sh
@@ -52,7 +52,6 @@ if [[ $browser = 'chrome' ]];then
   # More chrome specific things
   sed -i 's/"persistent": true/"persistent": false/' tmp
   sed -i 's/browser_style/chrome_style/' tmp
-  sed -i 's/"default": "Alt+X"/"default": "Alt+C"/' tmp
   mv tmp manifest.json
 fi
 zip -r $PACKAGE_NAME.zip *

--- a/pack_plugin.sh
+++ b/pack_plugin.sh
@@ -52,6 +52,7 @@ if [[ $browser = 'chrome' ]];then
   # More chrome specific things
   sed -i 's/"persistent": true/"persistent": false/' tmp
   sed -i 's/browser_style/chrome_style/' tmp
+  sed -i 's/"default": "Alt+X"/"default": "Alt+C"/' tmp
   mv tmp manifest.json
 fi
 zip -r $PACKAGE_NAME.zip *


### PR DESCRIPTION
By default, we override the default Crowdin shortcut for Copy Source button, but it is configurable in Extension settings.

In Firefox, it seems that the plugin shortcut is not able to override the Crowdin shortcut so we need a different one.

- [x] Check the default Crowdin shortcut in Windows and  verify we are able to override it

Closes #9 