### PR TITLE
Migrate to manifest V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 KhanAcademyLibs/math-translator.js
+*.zip

--- a/manifest.json
+++ b/manifest.json
@@ -19,8 +19,7 @@
   },
    "options_ui": {
     "page": "options.html",
-    "open_in_tab": true,
-    "browser_style": true
+    "open_in_tab": true
   },
 "commands": {
   "translate-math": {

--- a/manifest.json
+++ b/manifest.json
@@ -7,12 +7,15 @@
     "activeTab",
     "storage"
   ],
-  "web_accessible_resources": [
-    "5commastyle.gif"
-  ],
+  "web_accessible_resources": [{
+    "resources": ["5commastyle.gif"],
+    "matches": [
+      "http://crowdin.com/*",
+      "https://crowdin.com/*"
+    ]
+  }],
   "background": {
-    "scripts": ["background.js"],
-    "persistent": true
+    "service_worker": "background.js"
   },
    "options_ui": {
     "page": "options.html",
@@ -31,7 +34,6 @@
   "content_scripts": [
     {
       "matches": [
-        "http://crowdin.com/translate/khanacademy/*",
         "https://crowdin.com/translate/khanacademy/*"
       ],
       "js": [
@@ -49,5 +51,5 @@
     "48": "khan-logo-new-48.png",
     "128": "khan-logo-new-128.png"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }

--- a/pack_plugin.sh
+++ b/pack_plugin.sh
@@ -5,7 +5,8 @@
 # or Firefox
 # https://addons.mozilla.org/en-US/developers/addon/khan-academy-dots/edit
 
-set -eou pipefail
+set -euo pipefail
+set -x
 
 browser=${1-}
 if [[ -z $browser ]];then
@@ -21,52 +22,27 @@ fi
 
 # Don't forget to bump version in manifest.json before each official publish!
 version=$(grep '"version"' manifest.json | awk -F'"' '{print $4}')
-REPO_NAME=KhanAcademyDots
-PACKAGE_NAME=${REPO_NAME}-${version}-${browser}
-
-cd ../ || exit 1
-
-rm -rf $PACKAGE_NAME.zip
-
-if [[ -e $PACKAGE_NAME ]];then
-  rm -r $PACKAGE_NAME
+if [[ -z $version ]];then
+  echo "ERROR: Could not determine version"
+  exit 1
 fi
 
-if [[ ! -d $REPO_NAME ]];then
-   echo "ERROR: Directory $REPO_NAME does not exist!"
-   exit 1
-fi
+PACKAGE_NAME=KhanAcademyDots-${version}-${browser}
 
-if [[ -d $PACKAGE_NAME ]];then
-  rm -rf $PACKAGE_NAME
-fi
+rm -rf $PACKAGE_NAME.zip $PACKAGE_NAME
+mkdir $PACKAGE_NAME
 
-cp -r $REPO_NAME $PACKAGE_NAME
-
-cd $PACKAGE_NAME || exit 1
-if [[ $? -ne 0 ]];then
-   echo "ERROR: Could not enter dir ../$PACKAGE_NAME"
-   exit 1
-fi
+cp *js *html *png *gif manifest.json $PACKAGE_NAME
+cp -r 3rdPartyLibs KhanAcademyLibs $PACKAGE_NAME
 
 # Get rid of module.exports and babel requires,
 # which are not supported in browser plugins
 nlines=$(grep -n 'module.exports' translation-assistant/lib/math-translator.js | awk -F":" '{print $1;end}')
 let nlines--
 head -n $nlines translation-assistant/lib/math-translator.js |\
- egrep -v 'require(.+)' > KhanAcademyLibs/math-translator.js
+ egrep -v 'require(.+)' > $PACKAGE_NAME/KhanAcademyLibs/math-translator.js
 
-rm -rf node_modules/ package.json package-lock.json .eslintrc .git/ *.md pack_plugin.sh translation-assistant/
-if [[ $browser = 'chrome' ]];then
-  # We need to exclude Firefox-specific manifest entries
-  grep -v -e gecko -e browser_specific_settings manifest.json > tmp
-  # More chrome specific things
-  sed -i 's/"persistent": true/"persistent": false/' tmp
-  sed -i 's/browser_style/chrome_style/' tmp
-  mv tmp manifest.json
-fi
-zip -r $PACKAGE_NAME.zip *
-mv $PACKAGE_NAME.zip ../
-cd .. || exit 1
+cd $PACKAGE_NAME
+zip -r ../${PACKAGE_NAME}.zip *
 
-rm -rf $PACKAGE_NAME
+rm -r ../$PACKAGE_NAME

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "khan-academy-dots",
   "description": "Translate math notation in Khan Academy Crowdin strings.",
   "author": "Daniel Hollas & Szymon Bubak & Krzysztof Krystek & Robert Pala",
-  "version": "3.3.0",
+  "version": "3.5.0",
   "main": "app.js",
   "scripts": {
     "lint": "eslint *.js",


### PR DESCRIPTION
Support for manifest V2 in Chrome ends by Jan 2023, see https://developer.chrome.com/blog/mv2-transition/

Test plan:
 - In Chrome open chrome://extensions
 - Uninstall/disable any previously installed versions
 - Click on "Load unpacked" to install the extension
   directly from the repo folder. Make sure no warnings are emitted.
 - Still on the extension page, open hamburger menu and open keyboard
   shortcuts page. Set the shortcut for the extension.
 - Open any exercice in Khan Translation Editor, e.g.
   https://www.khanacademy.org/translations/edit/cs/math/arithmetic/x18ca194a:add-and-subtract-decimals/x18ca194a:adding-decimals-intro/e/add-decimals-visually/tree/upstream?return_to=/translations/cs/math/arithmetic/x18ca194a:add-and-subtract-decimals/x18ca194a:adding-decimals-intro/e&lang=en
 - You should see an extra copy button in the crowdin window
   with a comma inside.
 - Clicking a button for the first time should open
   options page. Set language to Czech.
 - Clicking a button now should copy English string
   and autotranslate math.
 - Find a string with a decimal numbers, verify that decimal points
   are translated to decimal comma escaped by braces '{,}'
 - Verify that the keyboard shortcut triggers the button.

Closes #20.

Support for Firefox is beyond the scope here, I'll take a look later.